### PR TITLE
Remove dependency on activesupport

### DIFF
--- a/lib/openlogi.rb
+++ b/lib/openlogi.rb
@@ -1,7 +1,6 @@
 require "openlogi/version"
 require "typhoeus"
 require "json"
-require "active_support/core_ext/module/delegation"
 require "hashie"
 
 require "openlogi/api/items"

--- a/lib/openlogi/response.rb
+++ b/lib/openlogi/response.rb
@@ -1,10 +1,11 @@
 module Openlogi
   class Response
     include Enumerable
+    extend Forwardable
 
     attr_reader :response
-    delegate :success?, to: :response
-    delegate :each, :each_pair, :fetch, :to_hash, to: :json_response
+    def_delegator :response, :success?
+    def_delegators :json_response, :each, :each_pair, :fetch, :to_hash
 
     def initialize(response)
       @response = response

--- a/openlogi.gemspec
+++ b/openlogi.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "typhoeus", "~> 1.0.1"
-  spec.add_dependency "activesupport", ">= 4.0"
   spec.add_dependency "json", "~> 1.7"
   spec.add_dependency "hashie", "~> 3.4"
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
We don't need this and it will cause problems for anybody using older versions of rails.