### PR TITLE
Add missing stock properties

### DIFF
--- a/lib/openlogi/base_object.rb
+++ b/lib/openlogi/base_object.rb
@@ -3,6 +3,17 @@ module Openlogi
     include Hashie::Extensions::Dash::Coercion
     include Hashie::Extensions::IndifferentAccess
 
+    def initialize(attributes = {}, &block)
+      attributes.each_key do |key|
+        if !self.class.property?(key)
+          attributes.delete(key)
+          warn "#{key} is not a property of #{self.class} and will be ignored."
+        end
+      end
+
+      super
+    end
+
     property :error
     property :errors
     property :error_description

--- a/lib/openlogi/response.rb
+++ b/lib/openlogi/response.rb
@@ -5,7 +5,7 @@ module Openlogi
 
     attr_reader :response
     def_delegator :response, :success?
-    def_delegators :json_response, :each, :each_pair, :fetch, :to_hash
+    def_delegators :json_response, :each, :each_pair, :each_key, :fetch, :to_hash
 
     def initialize(response)
       @response = response

--- a/lib/openlogi/stock.rb
+++ b/lib/openlogi/stock.rb
@@ -8,5 +8,9 @@ module Openlogi
     property :quantity, coerce: Integer
     property :size, coerce: Enum[:SS, :S, :M, :L, :LL, :'3L']
     property :weight, coerce: Integer
+    property :backordered, coerce: Integer
+    property :created_at, coerce: DateTime
+    property :updated_at, coerce: DateTime
+    property :reserved, coerce: Integer
   end
 end


### PR DESCRIPTION
Added some missing properties on the `Openlogi::Stock` model.

The default behavior for a `Hashie::Dash` is to raise an error when setting a property value that is not defined. That's good because we keep up to date with what's missing from our client models, but crashing the client is not very good. I'm overriding the default behavior to just warn the user and not set the value.