### PR TITLE
Dup attributes to a hash in base object

### DIFF
--- a/lib/openlogi/base_object.rb
+++ b/lib/openlogi/base_object.rb
@@ -4,14 +4,15 @@ module Openlogi
     include Hashie::Extensions::IndifferentAccess
 
     def initialize(attributes = {}, &block)
-      attributes.each_key do |key|
+      @attributes = attributes.to_hash.dup
+      @attributes.each_key do |key|
         if !self.class.property?(key)
-          attributes.delete(key)
+          @attributes.delete(key)
           warn "#{key} is not a property of #{self.class} and will be ignored."
         end
       end
 
-      super
+      super(@attributes, &block)
     end
 
     property :error

--- a/spec/openlogi/base_object_spec.rb
+++ b/spec/openlogi/base_object_spec.rb
@@ -1,10 +1,14 @@
 require "spec_helper"
 
+class DummyObject < Openlogi::BaseObject
+  property :bar
+end
+
 describe Openlogi::BaseObject do
   describe ".new" do
     it "issues warning about attributes not defined as properties on object" do
-      expect_any_instance_of(Openlogi::BaseObject).to receive(:warn).once.with("foo is not a property of Openlogi::BaseObject and will be ignored.")
-      object = Openlogi::BaseObject.new(foo: "bar")
+      expect_any_instance_of(DummyObject).to receive(:warn).once.with("foo is not a property of DummyObject and will be ignored.")
+      object = DummyObject.new(foo: "foo", bar: "bar")
     end
   end
 

--- a/spec/openlogi/base_object_spec.rb
+++ b/spec/openlogi/base_object_spec.rb
@@ -1,6 +1,13 @@
 require "spec_helper"
 
 describe Openlogi::BaseObject do
+  describe ".new" do
+    it "issues warning about attributes not defined as properties on object" do
+      expect_any_instance_of(Openlogi::BaseObject).to receive(:warn).once.with("foo is not a property of Openlogi::BaseObject and will be ignored.")
+      object = Openlogi::BaseObject.new(foo: "bar")
+    end
+  end
+
   describe "#valid?" do
     it "returns true if object has no errors" do
       object = Openlogi::BaseObject.new(errors: {})


### PR DESCRIPTION
I noticed that the code issuing a warning if an unexpected property is returned in a response actually fails because `Openlogi::Response` has no `delete` method. We don't want to actually delete anything from the json response so I decided instead to dup the response as a hash in base object and keep it around as `@attributes`, and then pass that on to `super` (`Hashie::Dash`).