### PR TITLE
Make valid? return false if record has error set

### DIFF
--- a/lib/openlogi/base_object.rb
+++ b/lib/openlogi/base_object.rb
@@ -20,7 +20,7 @@ module Openlogi
     property :error_description
 
     def valid?
-      errors.nil? || errors.empty?
+      error.nil? && (errors.nil? || errors.empty?)
     end
   end
 end

--- a/spec/openlogi/base_object_spec.rb
+++ b/spec/openlogi/base_object_spec.rb
@@ -13,7 +13,17 @@ describe Openlogi::BaseObject do
   end
 
   describe "#valid?" do
-    it "returns true if object has no errors" do
+    it "returns true if object has no error" do
+      object = Openlogi::BaseObject.new(error: nil)
+      expect(object.valid?).to eq(true)
+    end
+
+    it "returns false if object has an error" do
+      object = Openlogi::BaseObject.new(error: "validation_failed")
+      expect(object.valid?).to eq(false)
+    end
+
+    it "returns true if object has empty errors" do
       object = Openlogi::BaseObject.new(errors: {})
       expect(object.valid?).to eq(true)
     end


### PR DESCRIPTION
As I'm testing with the API I'm learning how it works. Just noticed that deleting a shipment can return the following response:

```json
{
  "error": "validation_failed",  
  "error_description": "出庫済もしくは準備中の依頼は削除できません"
}
```

In this case the response code is 422, but there are no `errors`... so basically we should just call the object invalid if `error` is present or `errors` is not empty.

What I'm trying to do here is to only raise if the response is *not* a validation error, and in other cases return an object with errors set on it. But this case breaks the existing pattern. We'll just need to keep updating this as we get a better handle on how openlogi validation works internally.