### PR TITLE
Add some useful shortcuts

### DIFF
--- a/lib/openlogi/api/endpoint.rb
+++ b/lib/openlogi/api/endpoint.rb
@@ -1,10 +1,17 @@
 module Openlogi
   module Api
     class Endpoint
+      extend Forwardable
+
       attr_reader :client
+      def_delegators :all, :map, :each, :first, :last, :count, :size
 
       def initialize(client)
         @client = client
+      end
+
+      def all
+        raise NotImplementedError
       end
 
       def resource_class

--- a/lib/openlogi/api/endpoint.rb
+++ b/lib/openlogi/api/endpoint.rb
@@ -1,16 +1,20 @@
 module Openlogi
   module Api
     class Endpoint
-      extend Forwardable
-
       attr_reader :client
-      def_delegators :all, :map, :each, :first, :last, :count, :size
 
       def initialize(client)
         @client = client
       end
 
-      def all
+      %w[map each first last count size].each do |method_name|
+        define_method method_name do |*args|
+          forwarded = args.empty? ? send(:all) : send(:all, args[0])
+          forwarded.send(method_name)
+        end
+      end
+
+      def all(*args)
         raise NotImplementedError
       end
 

--- a/spec/openlogi/api/endpoint_spec.rb
+++ b/spec/openlogi/api/endpoint_spec.rb
@@ -45,5 +45,19 @@ describe Openlogi::Api::Endpoint do
         expect(client.last_response).to eq(response)
       end
     end
+
+    describe "delegators" do
+      let(:endpoint) { Openlogi::Api::Endpoint.new(double("client")) }
+
+      it "delegates iterator methods to all with arguments" do
+        expect(endpoint).to receive(:all).with(stock: true).and_return(["first"])
+        expect(endpoint.first(stock: true)).to eq("first")
+      end
+
+      it "delegates iterator methods to all without arguments" do
+        expect(endpoint).to receive(:all).with(no_args).and_return(["first"])
+        expect(endpoint.first).to eq("first")
+      end
+    end
   end
 end


### PR DESCRIPTION
Allows you to do things like `client.shipments.first` and get the first shipment, etc., instead of `client.shipments.all.first`.