### PR TITLE
Don't raise if enum fails to match

### DIFF
--- a/lib/openlogi/enum.rb
+++ b/lib/openlogi/enum.rb
@@ -10,7 +10,8 @@ module Openlogi
       if @values.include?(normalized = v.to_sym)
         normalized
       else
-        raise ArgumentError, "Value must be one of #{@values.join(", ")}"
+        warn "Expected value to be one of #{@values.join(", ")}"
+        v
       end
     end
   end

--- a/lib/openlogi/enum.rb
+++ b/lib/openlogi/enum.rb
@@ -9,6 +9,8 @@ module Openlogi
     def self.coerce(v)
       if @values.include?(normalized = v.to_sym)
         normalized
+      elsif v == ""
+        nil
       else
         warn "Expected value to be one of #{@values.join(", ")}"
         v


### PR DESCRIPTION
We currently raise if an enum doesn't match any of its expected values, but this is a problem if for whatever reason the API returns something new and unexpected.

I've changed the code to output a warning and set the value as a string instead of a symbol.