### PR TITLE
Add Openlogi::Errors object

### DIFF
--- a/lib/openlogi/base_object.rb
+++ b/lib/openlogi/base_object.rb
@@ -16,7 +16,7 @@ module Openlogi
     end
 
     property :error
-    property :errors
+    property :errors, coerce: Openlogi::Errors
     property :error_description
 
     def valid?

--- a/lib/openlogi/base_object.rb
+++ b/lib/openlogi/base_object.rb
@@ -19,11 +19,11 @@ module Openlogi
     end
 
     property :error, coerce: String
-    property :errors, coerce: Openlogi::Errors
+    property :errors, coerce: Openlogi::Errors, default: {}
     property :error_description, coerce: String
 
     def valid?
-      error.nil? && (errors.nil? || errors.empty?)
+      error.nil? && errors.empty?
     end
   end
 end

--- a/lib/openlogi/base_object.rb
+++ b/lib/openlogi/base_object.rb
@@ -18,9 +18,9 @@ module Openlogi
       super(@attributes, &block)
     end
 
-    property :error
+    property :error, coerce: String
     property :errors, coerce: Openlogi::Errors
-    property :error_description
+    property :error_description, coerce: String
 
     def valid?
       error.nil? && (errors.nil? || errors.empty?)

--- a/lib/openlogi/base_object.rb
+++ b/lib/openlogi/base_object.rb
@@ -1,6 +1,9 @@
+require "openlogi/errors"
+
 module Openlogi
   class BaseObject < Hashie::Dash
     include Hashie::Extensions::Dash::Coercion
+    include Hashie::Extensions::MergeInitializer
     include Hashie::Extensions::IndifferentAccess
 
     def initialize(attributes = {}, &block)

--- a/lib/openlogi/errors.rb
+++ b/lib/openlogi/errors.rb
@@ -1,0 +1,13 @@
+require "openlogi/base_object"
+
+module Openlogi
+  class Errors < Hash
+    include Hashie::Extensions::Coercion
+    include Hashie::Extensions::MergeInitializer
+    include Hashie::Extensions::IndifferentAccess
+
+    def full_messages
+      values.join
+    end
+  end
+end

--- a/spec/openlogi/base_object_spec.rb
+++ b/spec/openlogi/base_object_spec.rb
@@ -38,4 +38,14 @@ describe Openlogi::BaseObject do
       expect(object.valid?).to eq(false)
     end
   end
+
+  describe "#errors" do
+    it "returns errors object with full messages" do
+      object = Openlogi::BaseObject.new(errors: {
+        "identifier" => ["order noを指定しない場合は、identifierを指定してください。"],
+        "order_no" => ["identifierを指定しない場合は、order noを指定してください。"]
+      })
+      expect(object.errors.full_messages).to eq("order noを指定しない場合は、identifierを指定してください。identifierを指定しない場合は、order noを指定してください。")
+    end
+  end
 end


### PR DESCRIPTION
This acts like activemodel validations, so you can call `full_messages` on the `errors` hash and it will join the errors into a single string:

```ruby
shipment.errors.full_messages
```