### PR TITLE
Add shipped action to shipments endpoint

### DIFF
--- a/lib/openlogi/api/shipments.rb
+++ b/lib/openlogi/api/shipments.rb
@@ -13,6 +13,10 @@ module Openlogi
         perform_request_with_objects(:get, "shipments", {})
       end
 
+      def shipped
+        perform_request_with_objects(:get, "shipments/shipped", {})
+      end
+
       def update(id, params)
         perform_request_with_object(:put, "shipments/#{id}", params)
       end

--- a/lib/openlogi/enum.rb
+++ b/lib/openlogi/enum.rb
@@ -7,7 +7,7 @@ module Openlogi
     end
 
     def self.coerce(v)
-      if @values.include?(normalized = v.to_sym)
+      if @values.include?(normalized = v.to_sym.upcase)
         normalized
       elsif v == ""
         nil

--- a/lib/openlogi/shipment.rb
+++ b/lib/openlogi/shipment.rb
@@ -30,7 +30,7 @@ module Openlogi
     property :cash_on_delivery, coerce: Boolean
     property :shipping_email
     property :message
-    property :status
+    property :status, coerce: Enum[:WAITING, :WORKING, :SHIPPED]
     property :items, coerce: Array[Item]
     property :tracking_code
   end

--- a/lib/openlogi/shipment.rb
+++ b/lib/openlogi/shipment.rb
@@ -32,5 +32,6 @@ module Openlogi
     property :message
     property :status
     property :items, coerce: Array[Item]
+    property :tracking_code
   end
 end

--- a/spec/openlogi/api/shipments_spec.rb
+++ b/spec/openlogi/api/shipments_spec.rb
@@ -57,9 +57,10 @@ describe Openlogi::Api::Shipments do
   end
 
   describe "#find" do
+    let(:status) { "shipped" }
     let!(:stub) do
       stub_request(:get, "#{base_url}/#{id}").
-        to_return(body: response_shipment.merge("status" => "shipped", "shipped_at" => "2015-01-01T15:00:00+0900").to_json)
+        to_return(body: response_shipment.merge("shipped_at" => "2015-01-01T15:00:00+0900").to_json)
     end
     let(:do_request) { endpoint.find(id) }
 
@@ -162,7 +163,7 @@ describe Openlogi::Api::Shipments do
     let(:status) { "shipped" }
     let!(:stub) do
       stub_request(:get, "#{base_url}/shipped").
-        to_return(body: {"shipments" => [response_shipment] }.to_json)
+        to_return(body: {"shipments" => [response_shipment.merge(tracking_code: "516118852152")] }.to_json)
     end
     let(:do_request) { endpoint.shipped }
 
@@ -175,6 +176,7 @@ describe Openlogi::Api::Shipments do
         shipment = shipments.first
         expect(shipment.id).to eq(id)
         expect(shipment.status).to eq("shipped")
+        expect(shipment.tracking_code).to eq("516118852152")
       end
     end
   end

--- a/spec/openlogi/api/shipments_spec.rb
+++ b/spec/openlogi/api/shipments_spec.rb
@@ -110,7 +110,7 @@ describe Openlogi::Api::Shipments do
         expect(shipment.gift_wrapping_type).to eq(:NAVY)
         expect(shipment.gift_sender_name).to eq("ブルー トー")
         expect(shipment.bundled_items).to eq(["DQ008","DQ009"])
-        expect(shipment.status).to eq("shipped")
+        expect(shipment.status).to eq(:SHIPPED)
         expect(shipment.shipped_at).to eq(DateTime.new(2015, 1, 1, 15, 0, 0, "JST"))
 
         # items
@@ -175,7 +175,7 @@ describe Openlogi::Api::Shipments do
 
         shipment = shipments.first
         expect(shipment.id).to eq(id)
-        expect(shipment.status).to eq("shipped")
+        expect(shipment.status).to eq(:SHIPPED)
         expect(shipment.tracking_code).to eq("516118852152")
       end
     end

--- a/spec/openlogi/api/shipments_spec.rb
+++ b/spec/openlogi/api/shipments_spec.rb
@@ -158,6 +158,27 @@ describe Openlogi::Api::Shipments do
     end
   end
 
+  describe "#shipped" do
+    let(:status) { "shipped" }
+    let!(:stub) do
+      stub_request(:get, "#{base_url}/shipped").
+        to_return(body: {"shipments" => [response_shipment] }.to_json)
+    end
+    let(:do_request) { endpoint.shipped }
+
+    it "assigns response" do
+      shipments = do_request
+
+      aggregate_failures "testing response" do
+        expect(shipments.size).to eq(1)
+
+        shipment = shipments.first
+        expect(shipment.id).to eq(id)
+        expect(shipment.status).to eq("shipped")
+      end
+    end
+  end
+
   describe "#update" do
     let(:bundled_items) { [] }
     let(:items) do


### PR DESCRIPTION
I added the "shipped" endpoint and also updated `Openlogi::Shipment` to include the tracking number, which is pretty important. I also switched to an enum for the shipment status -- the documentation says this is an enum but doesn't explicitly state the values it can have, but from responses it seems to have three important ones: `waiting`, `working` and `shipped`. I've normalized all enum values to upcased symbols (if for whatever reason we get some unexpected value the gem will warn the user and just set the value as a string).