### PR TITLE
Give each client its own configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-- 2.3.0
-- 2.2.3
+- 2.3.1
+- 2.2.5
 - 2.1.7
 before_install: gem install bundler -v 1.11.2
 notifications:

--- a/lib/openlogi.rb
+++ b/lib/openlogi.rb
@@ -28,13 +28,4 @@ require "openlogi/internal_server_error"
 require "openlogi/client"
 
 module Openlogi
-  class << self
-    def configure
-      yield configuration
-    end
-
-    def configuration
-      @configuration ||= Openlogi::Configuration.new
-    end
-  end
 end

--- a/lib/openlogi/client.rb
+++ b/lib/openlogi/client.rb
@@ -2,8 +2,12 @@ module Openlogi
   class Client
     attr_accessor :last_response
 
+    def configure
+      yield configuration
+    end
+
     def configuration
-      Openlogi.configuration
+      @configuration ||= Openlogi::Configuration.new
     end
 
     def test_mode?

--- a/lib/openlogi/version.rb
+++ b/lib/openlogi/version.rb
@@ -1,3 +1,3 @@
 module Openlogi
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/openlogi.gemspec
+++ b/openlogi.gemspec
@@ -35,4 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 1.24"
   spec.add_development_dependency "guard-rspec", "~> 4.6"
+  # remove once we deprecate ruby 2.1 support
+  spec.add_development_dependency "listen", "~> 3.0.5"
 end

--- a/spec/openlogi/client_spec.rb
+++ b/spec/openlogi/client_spec.rb
@@ -3,6 +3,27 @@ require "spec_helper"
 describe Openlogi::Client do
   let(:client) { Openlogi::Client.new }
 
+  describe "#configuration" do
+    it "returns a new configuration" do
+      expect(client.configuration).to be_a(Openlogi::Configuration)
+    end
+
+    it "memoizes configuration" do
+      configuration = client.configuration
+      expect(client.configuration).to eq(configuration)
+    end
+  end
+
+  describe "#configure" do
+    it "configures client" do
+      client.configure do |configuration|
+        configuration.access_token = "mytoken"
+      end
+
+      expect(client.access_token).to eq("mytoken")
+    end
+  end
+
   describe "#endpoint" do
     it "returns test point endpoint when test mode is true" do
       client = Openlogi::Client.new
@@ -10,7 +31,7 @@ describe Openlogi::Client do
     end
 
     it "returns production endpoint when test mode is false" do
-      allow(Openlogi.configuration).to receive(:test_mode).and_return(false)
+      allow(client.configuration).to receive(:test_mode).and_return(false)
       expect(client.endpoint).to eq("https://api.openlogi.com")
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,3 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 end
-
-Openlogi.configure do |c|
-  c.access_token = "accesstoken"
-end


### PR DESCRIPTION
Currently only one configuration is allowed, but we'd like to make it possible for different clients to have different configurations. This is easy to do by just moving the `configuration` and `configure` methods from `Openlogi` to `Openlogi::Client`.

This is a breaking change so bumping the version to 0.2.0.